### PR TITLE
Fixed false positive result

### DIFF
--- a/json-db-check.php
+++ b/json-db-check.php
@@ -72,7 +72,7 @@ ob_start();
 	{
 		$data = trim($data);
 
-		return ((substr($data, 0, 1) === '{') && (substr($data, -1, 1) === '}')) ? true : false;
+		return ((substr($data, 0, 1) === '{') && (substr($data, -1, 1) === '}')) ? false : true;
 	}
 
 	function is_json()


### PR DESCRIPTION
Fixing #6 

I think there was a confusion about the functions naming. However I'm not sure if sometimes non-json is allowed in those columns. Then the line might better be
```
return ((substr($data, 0, 1) === '{') && (substr($data, -1, 1) !== '}')) ? true : false;
```
or even better using regex?

At least now it indicates me the bad rows in my database.